### PR TITLE
Adding an option to hide the label of the checkbox!

### DIFF
--- a/src/examples/de/linearbits/examples/PreferencesExample.java
+++ b/src/examples/de/linearbits/examples/PreferencesExample.java
@@ -82,6 +82,11 @@ public class PreferencesExample {
             protected Boolean getValue() { return true; }
             protected void setValue(Object t) { /*(Boolean)t*/}
         });
+
+        window.addPreference(new PreferenceBoolean("BooleanPreference with hidden label", false, true) {
+            protected Boolean getValue() { return true; }
+            protected void setValue(Object t) { /*(Boolean)t*/}
+        });
         
     }
 }

--- a/src/main/de/linearbits/preferences/EditorBoolean.java
+++ b/src/main/de/linearbits/preferences/EditorBoolean.java
@@ -28,31 +28,43 @@ class EditorBoolean extends Editor<Boolean> {
     /** Widget*/
     private Button checkbox;
 
+    /** Label Visibility*/
+    private Boolean hideLabel;
+
     /**
      * Constructor
      * @param dialog
      */
-    public EditorBoolean(PreferencesDialog dialog, Boolean _default) {
+    public EditorBoolean(PreferencesDialog dialog, Boolean _default, boolean hideLabel ) {
         super(dialog, null, _default);
+        this.hideLabel = hideLabel;
     }
 
     @Override
     void createControl(final Composite parent) {
         checkbox = new Button(parent, SWT.CHECK);
         checkbox.setSelection(false);
-        checkbox.setText(this.getDialog().getConfiguration().getStringNo());
+        if (! hideLabel) {
+            checkbox.setText(this.getDialog().getConfiguration().getStringNo());
+        }else {
+        	checkbox.setText("");
+        }
         checkbox.setLayoutData(GridDataFactory.swtDefaults().grab(true, false).indent(0, 0).align(SWT.FILL, SWT.FILL).create());
         checkbox.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent arg0) {
                 setValid(true);
                 update();
-                if (checkbox.getSelection()) {
-                    checkbox.setText(getDialog().getConfiguration().getStringYes());
-                } else {
-                    checkbox.setText(getDialog().getConfiguration().getStringNo());
-                }
-            }
+                if (! hideLabel) {
+	                if  (checkbox.getSelection()) {
+	                    checkbox.setText(getDialog().getConfiguration().getStringYes());
+	                } else {
+	                    checkbox.setText(getDialog().getConfiguration().getStringNo());
+	                };
+                }else {
+                	checkbox.setText("");	
+                };
+            };
         });
         
         super.createUndoButton(parent);
@@ -83,7 +95,11 @@ class EditorBoolean extends Editor<Boolean> {
     void setValue(Object t) {
         setInitialValue((Boolean) t);
         checkbox.setSelection((Boolean) t);
-        checkbox.setText((Boolean) t ? getDialog().getConfiguration().getStringYes() : getDialog().getConfiguration().getStringNo());
+        if (! hideLabel){
+           checkbox.setText((Boolean) t ? getDialog().getConfiguration().getStringYes() : getDialog().getConfiguration().getStringNo());
+        }else {
+        	checkbox.setText("");
+        }
         super.update();
     }
 }

--- a/src/main/de/linearbits/preferences/PreferenceBoolean.java
+++ b/src/main/de/linearbits/preferences/PreferenceBoolean.java
@@ -18,15 +18,29 @@ package de.linearbits.preferences;
  */
 public abstract class PreferenceBoolean extends Preference<Boolean> {
 
+	// view or hide the label in chkBox
+	private Boolean hideLabel = false;
+	
+    /**
+     * Constructor
+     * @param label
+     * @param default
+     * @param hideLabel
+     */
+    public PreferenceBoolean(String label, Boolean _default, Boolean hideLabel) {
+        super(label, _default);
+        this.hideLabel = hideLabel;
+    }
+        
     /**
      * Constructor
      * @param label
      * @param default
      */
-    public PreferenceBoolean(String label, Boolean _default) {
+    public PreferenceBoolean(String label, Boolean _default ) {
         super(label, _default);
     }
-    
+        
     /**
      * Constructor
      * @param label
@@ -37,11 +51,20 @@ public abstract class PreferenceBoolean extends Preference<Boolean> {
 
     @Override
     protected Editor<Boolean> getEditor() {
-        return new EditorBoolean(getDialog(), getDefault());
+        return new EditorBoolean(getDialog(), getDefault(),this.hideLabel);
     }
 
     @Override
     protected Validator<Boolean> getValidator() {
         return null;
     }
+
+    public Boolean getHideLabel() {
+		return hideLabel;
+	}
+
+	public void setHideLabel(Boolean hideLabel) {
+		this.hideLabel = hideLabel;
+		if (hideLabel == null) { throw new NullPointerException("hideLabel must not be null!"); }
+	}
 }


### PR DESCRIPTION
The current implementation adds a label Yes/No to a checkbox. This PR allows controlling the visibility of such labels e.g. 


        window.addPreference(new PreferenceBoolean("BooleanPreference", false) {
            protected Boolean getValue() { return true; }
            protected void setValue(Object t) { /*(Boolean)t*/}
        });

        window.addPreference(new PreferenceBoolean("BooleanPreference with hidden label", false, true) {
            protected Boolean getValue() { return true; }
            protected void setValue(Object t) { /*(Boolean)t*/}
        });

This is useful to handle this arx enhancement [issue](https://github.com/arx-deidentifier/arx/issues/367).


